### PR TITLE
Make CI upload non-DOS games binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.6
       - name: Build
         run: ./build.bat
       - name: Upload a Build Artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,6 @@ jobs:
           # Artifact name
           name: Binaries
           # A file, directory or wildcard pattern that describes what to upload
-          path: dosbox_*.exe
+          path: "*.exe"
           # The desired behavior if no files are found using the provided path.
           if-no-files-found: error

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Build
         run: ./build.bat
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v4.3.3
         with:
           # Artifact name
           name: Binaries


### PR DESCRIPTION
- Upload non-DOS games binaries too (Red Faction)
- Update actions used in the workflow: those versions were deprecated and set to be dead in november this year